### PR TITLE
Add Support for x.com Domain in Twitter Links

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ bot
     console.log("Bot started");
   });
 
-const rTwitterLink = /^(\w+:\/\/)?(?:mobile\.)?twitter\.com\b/i;
+const rTwitterLink = /^(\w+:\/\/)?(?:mobile\.)?(twitter\.com|x\.com)\b/i;
 
 function extractTwitterLinks(text?: string, entities: MessageEntity[] = []) {
   return entities


### PR DESCRIPTION
Add Support for x.com Domain in Twitter LinksThis PR updates our link detection to support both `twitter.com` and the new `x.com` domain. After Elon Musk acquired Twitter on **October 27, 2022**, the platform rebranded as X, with URLs now redirecting to `x.com` as of **July 24, 2023**.

## What's Changed

- **Regex Update**: The regex now matches both `twitter.com` and `x.com` URLs, ensuring the app continues to handle links correctly.

## Why It Matters

With the rebranding, links are now pointing to `x.com`. This update ensures the link detection works with both domains.

Please review the changes to ensure everything is covered.